### PR TITLE
feat: ScholarshipCard에서 period가 없는 경우 "알 수 없음"으로 표시

### DIFF
--- a/frontend/src/components/Notices/ScholarshipCard.js
+++ b/frontend/src/components/Notices/ScholarshipCard.js
@@ -7,7 +7,13 @@ import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import { useNavigate } from 'react-router-dom';
 
 const calculateDDay = (period) => {
+  if (!period || !period.includes('~')) 
+    return '알 수 없음';
+
   const [start, end] = period.split('~');
+  if (!end || isNaN(new Date(end).getTime()))
+    return '알 수 없음';
+
   const endDate = new Date(end.trim());
   const today = new Date();
   const diffDays = Math.ceil((endDate - today) / (1000 * 60 * 60 * 24));


### PR DESCRIPTION
## 변경 사항
### 1. 문제 원인
   - `aid-backend`의 `main` 브랜치와 연결되지 않는 문제가 있었는데, 데이터베이스에서 `period` 값이 존재하지 않는 경우가 있었기 때문입니다.
   - 일부 장학금 공고는 모집 기간(`period`) 정보를 제공하지 않아서 `period` 값이 존재하지 않는 데이터가 존재합니다.

### 2. 해결 방법
   - `ScholarshipCard`의 `calculateDDay` 함수에 `period`가 없거나 `end`가 없는 경우 예외처리를 추가했습니다.
   - 해당 상황에서 "마감" 대신 "알 수 없음"으로 표시되도록 처리했습니다.